### PR TITLE
Implemented a new option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+.DS_Store
+.vscode/

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ options
 -------
 
 - start
- - where to start reading. defaults to the end of the file
+  - where to start reading. defaults to the end of the file
 
 - end
   - where to stop reading. defaults to 0. ie i start from 1000 and stop at 10
 
 - block
-  - number of bytes to read at a time
+  - number of bytes to read at a time (default: 1024 bytes)
 
+- shorterFirst
+  - if the filesize is not a multiple of the blocksize, make the first block read (from the nd of the file) shorter, instead of the last (in the beginning of the file) (default: false)


### PR DESCRIPTION
When the filesize in bytes is not a multiple of the blocksize, there's one block read that will not be complete. Let's call this block **_the shorter block_**.

In the case of your lib **_the shorter block_** is always the last one - that corresponds to very first bytes of the file.

I had a use-case where I needed **_the shorter block_** to be read first (instead of last) so I implemented a new boolean option called ``shorterFirst``, which defaults to false (meaning it preserves the behavior that you defined).

Please review it and tell me if this ok.

Thanks